### PR TITLE
Turn the key-listing script into a full Outline access-key CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test on Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['18', '20', '22']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # node --check only looks at its first argument, so check each file in turn.
+      - name: Check syntax
+        run: |
+          for file in shadowboxKey.js lib/*.js test/*.js; do
+            node --check "$file"
+          done
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check the CLI starts and prints help
+        run: node shadowboxKey.js --help
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
-# Project exclude paths
-/node_modules/
-/.idea/misc.xml
-/.idea/modules.xml
-/.idea/OutlineKeyAPI.iml
-/.idea/vcs.xml
-/.idea/
+# Dependencies
+node_modules/
+
+# IDE / editor files
+.idea/
+.vscode/
+*.iml
+
+# Environment files (never commit your Management API URL)
+.env
+.env.*
+
+# OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,9 +1,70 @@
-Usage:
+# ShadowboxKeys
 
-Step 1: change managementApiUrl variable, replace with Management API URL from Outline Manager
+A small Node.js utility that lists all access keys from your [Outline VPN](https://getoutline.org/) (Shadowbox) server and prints each key's access URL — optionally rewritten to use your own custom domain instead of the server's raw IP address.
 
-Step 2: change domain variable with a domain if you connected one.
+This is handy when you have pointed a domain at your Outline server and want to hand out `ss://` access keys that reference the domain rather than the IP.
 
-Step 3: go to terminal, run: npm install
+## How it works
 
-Step 4: then run: node shadowboxKey.js
+The script calls the Outline **Management API** (`GET /access-keys/`), which returns every access key on the server. For each key it prints the key's name followed by its access URL. If you set a custom domain, the IP address in each URL is replaced with your domain.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 12 or newer (with npm)
+- An Outline server set up via [Outline Manager](https://getoutline.org/get-started/)
+- Your server's **Management API URL** — in Outline Manager open your server, go to **Settings**, and copy the *Management API URL* (it looks like `https://1.2.3.4:16942/AbCdEf123...`)
+
+## Installation
+
+```bash
+git clone https://github.com/rahmanow/ShadowboxKeys.git
+cd ShadowboxKeys
+npm install
+```
+
+## Configuration
+
+You can configure the script either with environment variables (recommended — keeps secrets out of the code) or by editing the two constants at the top of `shadowboxKey.js`.
+
+| Setting | Environment variable | Description |
+| --- | --- | --- |
+| Management API URL | `OUTLINE_API_URL` | The Management API URL copied from Outline Manager. **Required.** |
+| Custom domain | `OUTLINE_DOMAIN` | A domain that points at your Outline server. Optional — leave empty to keep the raw IP in the access URLs. |
+
+> ⚠️ The Management API URL grants full administrative control of your Outline server. Treat it like a password: don't commit it to version control or share it.
+
+## Usage
+
+With environment variables:
+
+```bash
+OUTLINE_API_URL="https://1.2.3.4:16942/AbCdEf123" OUTLINE_DOMAIN="vpn.example.com" npm start
+```
+
+Or edit the variables at the top of `shadowboxKey.js`, then run:
+
+```bash
+npm start
+```
+
+Example output:
+
+```
+Alice  ss://Y2hhY2hhMjAt...@vpn.example.com:443/?outline=1
+Bob    ss://Y2hhY2hhMjAt...@vpn.example.com:443/?outline=1
+Completed. These are all you have!
+```
+
+## A note on TLS verification
+
+Outline servers use a self-signed TLS certificate for the Management API, so the script disables certificate verification (`rejectUnauthorized: false`) for that one request. This is normal for the Outline Management API, but it does mean the connection is not protected against man-in-the-middle attacks. Only run this against servers you control, ideally from a trusted network.
+
+## Troubleshooting
+
+- **`FetchError: request to ... failed`** — check that the Management API URL is correct and that port `16942` (or whichever port your URL shows) is reachable from your machine.
+- **`Cannot find module 'node-fetch'`** — run `npm install` in the project directory first.
+- **Keys print with the IP instead of your domain** — make sure `OUTLINE_DOMAIN` (or the `domain` constant) is set and non-empty.
+
+## License
+
+No license has been specified yet. Until one is added, all rights are reserved by the author.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # ShadowboxKeys
 
-A small Node.js utility that lists all access keys from your [Outline VPN](https://getoutline.org/) (Shadowbox) server and prints each key's access URL — optionally rewritten to use your own custom domain instead of the server's raw IP address.
+A command-line tool for managing access keys on your [Outline VPN](https://getoutline.org/) (Shadowbox) server. It lists, creates, renames and deletes keys, sets per-key data limits, reports how much data each key has used, and prints scannable QR codes so people can onboard with the Outline app instead of copy-pasting `ss://` strings.
 
-This is handy when you have pointed a domain at your Outline server and want to hand out `ss://` access keys that reference the domain rather than the IP.
-
-## How it works
-
-The script calls the Outline **Management API** (`GET /access-keys/`), which returns every access key on the server. For each key it prints the key's name followed by its access URL. If you set a custom domain, the IP address in each URL is replaced with your domain.
+It can also rewrite every access URL to use your own domain in place of the server's raw IP address — handy when you have pointed a domain at your Outline server.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) 12 or newer (with npm)
+- [Node.js](https://nodejs.org/) 14 or newer (with npm)
 - An Outline server set up via [Outline Manager](https://getoutline.org/get-started/)
 - Your server's **Management API URL** — in Outline Manager open your server, go to **Settings**, and copy the *Management API URL* (it looks like `https://1.2.3.4:16942/AbCdEf123...`)
 
@@ -24,46 +20,128 @@ npm install
 
 ## Configuration
 
-You can configure the script either with environment variables (recommended — keeps secrets out of the code) or by editing the two constants at the top of `shadowboxKey.js`.
+Configure the tool either with environment variables (recommended — keeps secrets out of the code) or by editing the two constants at the top of `shadowboxKey.js`.
 
 | Setting | Environment variable | Description |
 | --- | --- | --- |
 | Management API URL | `OUTLINE_API_URL` | The Management API URL copied from Outline Manager. **Required.** |
 | Custom domain | `OUTLINE_DOMAIN` | A domain that points at your Outline server. Optional — leave empty to keep the raw IP in the access URLs. |
 
+A convenient way to keep these out of your shell history is a `.env` file (already git-ignored) that you source before running:
+
+```bash
+# .env
+export OUTLINE_API_URL="https://1.2.3.4:16942/AbCdEf123"
+export OUTLINE_DOMAIN="vpn.example.com"
+```
+
+```bash
+source .env
+```
+
 > ⚠️ The Management API URL grants full administrative control of your Outline server. Treat it like a password: don't commit it to version control or share it.
 
-## Usage
+## Commands
 
-With environment variables:
+```
+node shadowboxKey.js <command> [options]
+```
+
+| Command | What it does |
+| --- | --- |
+| `list` | List every access key with its id, name, data limit and access URL |
+| `add <name>` | Create a new access key |
+| `remove <key>` | Delete an access key |
+| `rename <key> <new name>` | Rename an access key |
+| `limit <key> <size\|none>` | Set or clear a key's data limit |
+| `limit server <size\|none>` | Set or clear the server-wide default data limit |
+| `usage` | Show how much data each key has transferred |
+| `qr <key>` | Print a key's access URL as a scannable QR code |
+
+`<key>` may be either a key id or a key name. Running with no command at all is the same as `list`, so the original behaviour still works.
+
+| Option | Applies to | Effect |
+| --- | --- | --- |
+| `--qr` | `list`, `add` | Also print a QR code for each key |
+| `--json` | `list`, `usage` | Output JSON instead of a table |
+| `--csv` | `list`, `usage` | Output CSV instead of a table |
+| `--limit <size>` | `add` | Give the new key a data limit straight away |
+| `-h`, `--help` | — | Show usage |
+
+Sizes accept a unit suffix: `10GB`, `500MB`, `2TB`, or a plain byte count.
+
+## Examples
+
+List every key:
+
+```console
+$ node shadowboxKey.js list
+ID  NAME   LIMIT  ACCESS URL
+--  -----  -----  -----------------------------------------------------
+0   Alice  10 GB  ss://YWVzOnBhc3N3b3Jk@vpn.example.com:443/?outline=1
+1   Bob    -      ss://YWVzOnBhc3N3b3Jk2@vpn.example.com:444/?outline=1
+```
+
+Create a key with a 50 GB cap and show its QR code:
+
+```console
+$ node shadowboxKey.js add Carol --limit 50GB --qr
+Created key "Carol" (id 2)
+Data limit: 50 GB
+ss://bmV3a2V5@vpn.example.com:502/?outline=1
+
+Carol:
+█▀▀▀▀▀█ ▀▄█▀▄ █▀▀▀▀▀█
+█ ███ █ █▄▀ ▀ █ ███ █
+...
+```
+
+See who is using how much:
+
+```console
+$ node shadowboxKey.js usage
+ID  NAME   USED    LIMIT  OF LIMIT
+--  -----  ------  -----  --------
+0   Alice  3.0 GB  10 GB  30%
+1   Bob    512 MB  -      -
+
+Total transferred: 3.5 GB
+```
+
+Cap a heavy user, then lift the cap later:
 
 ```bash
-OUTLINE_API_URL="https://1.2.3.4:16942/AbCdEf123" OUTLINE_DOMAIN="vpn.example.com" npm start
+node shadowboxKey.js limit Alice 10GB
+node shadowboxKey.js limit Alice none
 ```
 
-Or edit the variables at the top of `shadowboxKey.js`, then run:
+Export usage for a spreadsheet:
 
 ```bash
-npm start
+node shadowboxKey.js usage --csv > usage.csv
 ```
 
-Example output:
+## Project layout
 
 ```
-Alice  ss://Y2hhY2hhMjAt...@vpn.example.com:443/?outline=1
-Bob    ss://Y2hhY2hhMjAt...@vpn.example.com:443/?outline=1
-Completed. These are all you have!
+shadowboxKey.js    CLI entry point: argument parsing and commands
+lib/outline.js     Outline Management API client
+lib/format.js      Byte formatting, size parsing, table/CSV output
+lib/errors.js      UserError, for messages shown without a stack trace
 ```
 
 ## A note on TLS verification
 
-Outline servers use a self-signed TLS certificate for the Management API, so the script disables certificate verification (`rejectUnauthorized: false`) for that one request. This is normal for the Outline Management API, but it does mean the connection is not protected against man-in-the-middle attacks. Only run this against servers you control, ideally from a trusted network.
+Outline servers use a self-signed TLS certificate for the Management API, so the tool disables certificate verification (`rejectUnauthorized: false`) for those requests. This is normal for the Outline Management API, but it does mean the connection is not protected against man-in-the-middle attacks. Only run this against servers you control, ideally from a trusted network.
 
 ## Troubleshooting
 
-- **`FetchError: request to ... failed`** — check that the Management API URL is correct and that port `16942` (or whichever port your URL shows) is reachable from your machine.
+- **`Please configure your Management API URL first`** — set `OUTLINE_API_URL`, or replace the placeholder in `shadowboxKey.js`.
+- **`Could not reach the Outline server`** — check that the Management API URL is correct and that its port (usually `16942`) is reachable from your machine.
 - **`Cannot find module 'node-fetch'`** — run `npm install` in the project directory first.
+- **`Management API responded with 404`** — your Outline server may be running an older release that lacks data-limit or metrics endpoints. Upgrade the server, or stick to `list`, `add`, `remove` and `rename`.
 - **Keys print with the IP instead of your domain** — make sure `OUTLINE_DOMAIN` (or the `domain` constant) is set and non-empty.
+- **`DeprecationWarning: The punycode module is deprecated`** — harmless, and emitted by the `node-fetch` dependency on newer Node versions. Silence it with `NODE_NO_WARNINGS=1`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ShadowboxKeys
 
+[![CI](https://github.com/rahmanow/ShadowboxKeys/actions/workflows/ci.yml/badge.svg)](https://github.com/rahmanow/ShadowboxKeys/actions/workflows/ci.yml)
+
 A command-line tool for managing access keys on your [Outline VPN](https://getoutline.org/) (Shadowbox) server. It lists, creates, renames and deletes keys, sets per-key data limits, reports how much data each key has used, and prints scannable QR codes so people can onboard with the Outline app instead of copy-pasting `ss://` strings.
 
 It can also rewrite every access URL to use your own domain in place of the server's raw IP address — handy when you have pointed a domain at your Outline server.
@@ -128,7 +130,20 @@ shadowboxKey.js    CLI entry point: argument parsing and commands
 lib/outline.js     Outline Management API client
 lib/format.js      Byte formatting, size parsing, table/CSV output
 lib/errors.js      UserError, for messages shown without a stack trace
+test/              Unit tests, run with the built-in Node test runner
 ```
+
+## Development
+
+Run the test suite:
+
+```bash
+npm test
+```
+
+The tests cover the pure logic — size parsing and formatting, access-URL rewriting, table and CSV rendering, argument parsing and key lookup — and need Node 18 or newer for the built-in test runner, even though the tool itself runs on Node 14+.
+
+Every push and pull request runs the suite on Node 18, 20 and 22 via GitHub Actions, along with a syntax check and an audit of production dependencies. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
 ## A note on TLS verification
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * An error caused by bad input or a server response rather than a bug.
+ * The CLI prints these as a plain message, without a stack trace.
+ */
+class UserError extends Error {}
+
+module.exports = { UserError };

--- a/lib/format.js
+++ b/lib/format.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const { UserError } = require('./errors');
+
+const UNITS = [
+    { suffix: 'TB', bytes: 1024 ** 4 },
+    { suffix: 'GB', bytes: 1024 ** 3 },
+    { suffix: 'MB', bytes: 1024 ** 2 },
+    { suffix: 'KB', bytes: 1024 },
+];
+
+/** Renders a byte count as a short human-readable string, e.g. 1536 -> "1.5 KB". */
+function formatBytes(bytes) {
+    if (!bytes) return '0 B';
+    for (const unit of UNITS) {
+        if (bytes >= unit.bytes) {
+            const value = bytes / unit.bytes;
+            return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${unit.suffix}`;
+        }
+    }
+    return `${bytes} B`;
+}
+
+/**
+ * Parses a human-written size such as "10GB", "500 MB" or "1073741824" into bytes.
+ * Throws if the input cannot be understood.
+ */
+function parseBytes(input) {
+    const match = String(input).trim().match(/^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB)?$/i);
+    if (!match) {
+        throw new UserError(`Could not understand the size "${input}". Try something like 10GB or 500MB.`);
+    }
+    const value = parseFloat(match[1]);
+    const suffix = (match[2] || 'B').toUpperCase();
+    const unit = UNITS.find(u => u.suffix === suffix);
+    return Math.round(value * (unit ? unit.bytes : 1));
+}
+
+/** Rewrites the host in an ss:// access URL, leaving port, query and fragment intact. */
+function rewriteAccessUrl(accessUrl, fromHost, toHost) {
+    if (!accessUrl || fromHost === toHost) return accessUrl;
+    return accessUrl.replace('@' + fromHost + ':', '@' + toHost + ':');
+}
+
+/** Prints an array of row objects as an aligned text table. */
+function printTable(columns, rows) {
+    if (rows.length === 0) {
+        console.log('(none)');
+        return;
+    }
+    const widths = columns.map(col =>
+        Math.max(col.header.length, ...rows.map(row => String(row[col.key] ?? '').length))
+    );
+    const line = cells =>
+        cells.map((cell, i) => String(cell ?? '').padEnd(widths[i])).join('  ').trimEnd();
+
+    console.log(line(columns.map(col => col.header)));
+    console.log(line(widths.map(width => '-'.repeat(width))));
+    for (const row of rows) {
+        console.log(line(columns.map(col => row[col.key])));
+    }
+}
+
+/** Prints rows as CSV, quoting fields that need it. */
+function printCsv(columns, rows) {
+    const escape = value => {
+        const text = String(value ?? '');
+        return /[",\n]/.test(text) ? '"' + text.replace(/"/g, '""') + '"' : text;
+    };
+    console.log(columns.map(col => escape(col.header)).join(','));
+    for (const row of rows) {
+        console.log(columns.map(col => escape(row[col.key])).join(','));
+    }
+}
+
+module.exports = { formatBytes, parseBytes, rewriteAccessUrl, printTable, printCsv };

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const fetch = require('node-fetch');
+const https = require('https');
+const { UserError } = require('./errors');
+
+// Outline's Management API is served with a self-signed certificate, so
+// certificate verification has to be disabled. Only point this client at
+// servers you control.
+const agent = new https.Agent({ rejectUnauthorized: false });
+
+class OutlineClient {
+    constructor(managementApiUrl) {
+        this.baseUrl = managementApiUrl.replace(/\/+$/, '');
+        this.hostname = new URL(this.baseUrl).hostname;
+    }
+
+    async request(method, path, body) {
+        const options = { method, agent };
+        if (body !== undefined) {
+            options.body = JSON.stringify(body);
+            options.headers = { 'Content-Type': 'application/json' };
+        }
+
+        let response;
+        try {
+            response = await fetch(this.baseUrl + path, options);
+        } catch (err) {
+            throw new UserError(`Could not reach the Outline server: ${err.message}`);
+        }
+
+        if (!response.ok) {
+            throw new UserError(
+                `Management API responded with ${response.status} ${response.statusText} for ${method} ${path}`
+            );
+        }
+
+        // 204 No Content, which most write endpoints return.
+        if (response.status === 204) return null;
+
+        const text = await response.text();
+        return text ? JSON.parse(text) : null;
+    }
+
+    async listKeys() {
+        const data = await this.request('GET', '/access-keys/');
+        return (data && data.accessKeys) || [];
+    }
+
+    async createKey(name) {
+        const key = await this.request('POST', '/access-keys');
+        if (name && key) {
+            await this.renameKey(key.id, name);
+            key.name = name;
+        }
+        return key;
+    }
+
+    removeKey(id) {
+        return this.request('DELETE', `/access-keys/${encodeURIComponent(id)}`);
+    }
+
+    renameKey(id, name) {
+        return this.request('PUT', `/access-keys/${encodeURIComponent(id)}/name`, { name });
+    }
+
+    setKeyDataLimit(id, bytes) {
+        return this.request('PUT', `/access-keys/${encodeURIComponent(id)}/data-limit`, {
+            limit: { bytes },
+        });
+    }
+
+    clearKeyDataLimit(id) {
+        return this.request('DELETE', `/access-keys/${encodeURIComponent(id)}/data-limit`);
+    }
+
+    setServerDataLimit(bytes) {
+        return this.request('PUT', '/server/access-key-data-limit', { limit: { bytes } });
+    }
+
+    clearServerDataLimit() {
+        return this.request('DELETE', '/server/access-key-data-limit');
+    }
+
+    async getTransferMetrics() {
+        const data = await this.request('GET', '/metrics/transfer');
+        return (data && data.bytesTransferredByUserId) || {};
+    }
+}
+
+module.exports = { OutlineClient };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "shadowbox-keys",
       "version": "1.1.0",
       "dependencies": {
-        "node-fetch": "^2.7.0"
+        "node-fetch": "^2.7.0",
+        "qrcode-terminal": "^0.12.0"
       },
       "engines": {
         "node": ">=12"
@@ -32,6 +33,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,26 @@
 {
-  "name": "OutlineKeyAPI",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "name": "shadowbox-keys",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "node-fetch": {
+  "packages": {
+    "": {
+      "name": "shadowbox-keys",
+      "version": "1.1.0",
+      "dependencies": {
+        "node-fetch": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,52 @@
       "name": "shadowbox-keys",
       "version": "1.1.0",
       "dependencies": {
-        "node-fetch": "^2.6.0"
+        "node-fetch": "^2.7.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "shadowbox-keys",
-  "version": "1.1.0",
-  "description": "List Outline VPN (Shadowbox) access keys and rewrite their access URLs to use a custom domain",
+  "version": "2.0.0",
+  "description": "Command-line manager for Outline VPN (Shadowbox) access keys: list, create, rename, delete, set data limits, report usage and print QR codes",
   "main": "shadowboxKey.js",
+  "bin": {
+    "shadowbox-keys": "shadowboxKey.js"
+  },
   "scripts": {
     "start": "node shadowboxKey.js"
   },
@@ -11,16 +14,19 @@
     "outline-vpn",
     "shadowbox",
     "shadowsocks",
-    "access-keys"
+    "access-keys",
+    "cli",
+    "qrcode"
   ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rahmanow/ShadowboxKeys.git"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "dependencies": {
-    "node-fetch": "^2.7.0"
+    "node-fetch": "^2.7.0",
+    "qrcode-terminal": "^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "shadowbox-keys": "shadowboxKey.js"
   },
   "scripts": {
-    "start": "node shadowboxKey.js"
+    "start": "node shadowboxKey.js",
+    "test": "node --test"
   },
   "keywords": [
     "outline",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,25 @@
 {
-  "name": "OutlineKeyAPI",
-  "version": "1.0.0",
+  "name": "shadowbox-keys",
+  "version": "1.1.0",
+  "description": "List Outline VPN (Shadowbox) access keys and rewrite their access URLs to use a custom domain",
+  "main": "shadowboxKey.js",
+  "scripts": {
+    "start": "node shadowboxKey.js"
+  },
+  "keywords": [
+    "outline",
+    "outline-vpn",
+    "shadowbox",
+    "shadowsocks",
+    "access-keys"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rahmanow/ShadowboxKeys.git"
+  },
+  "engines": {
+    "node": ">=12"
+  },
   "dependencies": {
     "node-fetch": "^2.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "node": ">=12"
   },
   "dependencies": {
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.7.0"
   }
 }

--- a/shadowboxKey.js
+++ b/shadowboxKey.js
@@ -261,7 +261,12 @@ async function main() {
     await command(client, domain || client.hostname, args, flags);
 }
 
-main().catch(err => {
-    console.error(err instanceof UserError ? err.message : `Error: ${err.message}`);
-    process.exit(1);
-});
+// Only run when invoked directly, so the tests can import the helpers below.
+if (require.main === module) {
+    main().catch(err => {
+        console.error(err instanceof UserError ? err.message : `Error: ${err.message}`);
+        process.exit(1);
+    });
+}
+
+module.exports = { parseArgs, findKey };

--- a/shadowboxKey.js
+++ b/shadowboxKey.js
@@ -1,29 +1,43 @@
 // BEGIN Variables to change
-const managementApiUrl = 'https://xx.xx.xx.xxx:16942/k1CeXlhnXndHKlNTd3h-2w'; // Copy and paste Management API URL from Outline Manager Key Settings
-const domain = 'testdomain.com'; // set your custom domain if you have one
+// Prefer setting these via environment variables (OUTLINE_API_URL, OUTLINE_DOMAIN)
+// so the Management API URL never ends up committed to version control.
+const managementApiUrl = process.env.OUTLINE_API_URL || 'https://xx.xx.xx.xxx:16942/xxxxxxxxxxxxxxxxxxxxxx'; // Management API URL from Outline Manager > Settings
+const domain = process.env.OUTLINE_DOMAIN || ''; // set your custom domain if you have one, e.g. 'vpn.example.com'
 // END Variables to change
 
 
-const fetch = require('node-fetch'); // if error run: npm install node-fetch --save
-const https = require("https");
+const fetch = require('node-fetch'); // if error run: npm install
+const https = require('https');
+
+// Outline's Management API uses a self-signed certificate, so verification
+// must be disabled for this request. Only point this at servers you control.
 const agent = new https.Agent({ rejectUnauthorized: false });
 
-const url = managementApiUrl + '/access-keys/';
-const ip = managementApiUrl.split('/')[2].split(':')[0];
-const dom = () => { return domain ? domain : ip };
+if (managementApiUrl.includes('xx.xx.xx.xxx')) {
+    console.error('Please configure your Management API URL first.');
+    console.error('Set the OUTLINE_API_URL environment variable, or edit the managementApiUrl constant in shadowboxKey.js.');
+    process.exit(1);
+}
+
+const url = managementApiUrl.replace(/\/$/, '') + '/access-keys/';
+const ip = new URL(managementApiUrl).hostname;
+const host = domain || ip;
 
 const getKeys = async () => {
-    const response = await fetch( url, {agent} );
-    const myJson = await response.json();
-    const keys = myJson.accessKeys;
-    for ( let i=0; i<keys.length; i++ ) {
-        let key = keys[i];
-        let port = ':' + key['port'];
-        let name = key['name'];
-        let accessUrl = key['accessUrl'];
-        console.log(name + '' + accessUrl.replace(ip + port + '/?outline=1', dom()+ port));
+    const response = await fetch(url, { agent });
+    if (!response.ok) {
+        throw new Error(`Management API responded with ${response.status} ${response.statusText}`);
+    }
+    const { accessKeys } = await response.json();
+    for (const key of accessKeys) {
+        const port = ':' + key.port;
+        console.log(key.name + '\t' + key.accessUrl.replace(ip + port + '/?outline=1', host + port));
     }
 };
+
 getKeys()
-    .then(r => console.log("Completed. These are all you have!"))
-    .catch(err => console.log(err));
+    .then(() => console.log('Completed. These are all you have!'))
+    .catch(err => {
+        console.error('Failed to fetch access keys:', err.message);
+        process.exit(1);
+    });

--- a/shadowboxKey.js
+++ b/shadowboxKey.js
@@ -1,3 +1,6 @@
+#!/usr/bin/env node
+'use strict';
+
 // BEGIN Variables to change
 // Prefer setting these via environment variables (OUTLINE_API_URL, OUTLINE_DOMAIN)
 // so the Management API URL never ends up committed to version control.
@@ -5,39 +8,260 @@ const managementApiUrl = process.env.OUTLINE_API_URL || 'https://xx.xx.xx.xxx:16
 const domain = process.env.OUTLINE_DOMAIN || ''; // set your custom domain if you have one, e.g. 'vpn.example.com'
 // END Variables to change
 
+const qrcode = require('qrcode-terminal');
+const { OutlineClient } = require('./lib/outline');
+const { UserError } = require('./lib/errors');
+const { formatBytes, parseBytes, rewriteAccessUrl, printTable, printCsv } = require('./lib/format');
 
-const fetch = require('node-fetch'); // if error run: npm install
-const https = require('https');
+const USAGE = `ShadowboxKeys - manage access keys on your Outline VPN server
 
-// Outline's Management API uses a self-signed certificate, so verification
-// must be disabled for this request. Only point this at servers you control.
-const agent = new https.Agent({ rejectUnauthorized: false });
+Usage: node shadowboxKey.js <command> [options]
 
-if (managementApiUrl.includes('xx.xx.xx.xxx')) {
-    console.error('Please configure your Management API URL first.');
-    console.error('Set the OUTLINE_API_URL environment variable, or edit the managementApiUrl constant in shadowboxKey.js.');
-    process.exit(1);
+Commands:
+  list                        List every access key with its access URL
+  add <name>                  Create a new access key
+  remove <key>                Delete an access key
+  rename <key> <new name>     Rename an access key
+  limit <key> <size|none>     Set or clear a key's data limit (use "server" as
+                              the key to set the server-wide default limit)
+  usage                       Show data transferred per key
+  qr <key>                    Print an access key as a scannable QR code
+
+<key> may be either a key id or a key name.
+
+Options:
+  --qr        Also print a QR code for each key (list, add)
+  --json      Output JSON instead of a table (list, usage)
+  --csv       Output CSV instead of a table (list, usage)
+  --limit <size>  Data limit for a newly created key (add)
+  -h, --help  Show this help
+
+Sizes accept a unit suffix, e.g. 10GB, 500MB, 2TB.
+
+Configuration (environment variables):
+  OUTLINE_API_URL   Management API URL from Outline Manager > Settings
+  OUTLINE_DOMAIN    Optional custom domain to use in place of the server IP
+
+Examples:
+  node shadowboxKey.js list --qr
+  node shadowboxKey.js add Alice --limit 50GB
+  node shadowboxKey.js limit Alice 10GB
+  node shadowboxKey.js usage --csv
+`;
+
+/** Splits argv into positional arguments and a flag map. */
+function parseArgs(argv) {
+    const positional = [];
+    const flags = {};
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '-h' || arg === '--help') {
+            flags.help = true;
+        } else if (arg === '--limit') {
+            flags.limit = argv[++i];
+        } else if (arg.startsWith('--')) {
+            flags[arg.slice(2)] = true;
+        } else {
+            positional.push(arg);
+        }
+    }
+    return { positional, flags };
 }
 
-const url = managementApiUrl.replace(/\/$/, '') + '/access-keys/';
-const ip = new URL(managementApiUrl).hostname;
-const host = domain || ip;
+/** Finds a key by exact id, then by exact name, then by case-insensitive name. */
+function findKey(keys, needle) {
+    const byId = keys.find(key => String(key.id) === needle);
+    if (byId) return byId;
 
-const getKeys = async () => {
-    const response = await fetch(url, { agent });
-    if (!response.ok) {
-        throw new Error(`Management API responded with ${response.status} ${response.statusText}`);
+    const matches = keys.filter(key => key.name === needle);
+    const found = matches.length ? matches : keys.filter(
+        key => (key.name || '').toLowerCase() === needle.toLowerCase()
+    );
+
+    if (found.length === 0) {
+        throw new UserError(`No access key matches "${needle}". Run "list" to see the available keys.`);
     }
-    const { accessKeys } = await response.json();
-    for (const key of accessKeys) {
-        const port = ':' + key.port;
-        console.log(key.name + '\t' + key.accessUrl.replace(ip + port + '/?outline=1', host + port));
+    if (found.length > 1) {
+        const ids = found.map(key => key.id).join(', ');
+        throw new UserError(`"${needle}" matches more than one key (ids: ${ids}). Use the key id instead.`);
     }
+    return found[0];
+}
+
+function printQr(label, accessUrl) {
+    console.log(`\n${label}:`);
+    qrcode.generate(accessUrl, { small: true });
+}
+
+/** Chooses table, JSON or CSV output based on the flags given. */
+function output(columns, rows, flags) {
+    if (flags.json) console.log(JSON.stringify(rows, null, 2));
+    else if (flags.csv) printCsv(columns, rows);
+    else printTable(columns, rows);
+}
+
+const commands = {
+    async list(client, host, args, flags) {
+        const keys = await client.listKeys();
+        const rows = keys.map(key => ({
+            id: key.id,
+            name: key.name || '(unnamed)',
+            limit: key.dataLimit ? formatBytes(key.dataLimit.bytes) : '-',
+            accessUrl: rewriteAccessUrl(key.accessUrl, client.hostname, host),
+        }));
+
+        output(
+            [
+                { key: 'id', header: 'ID' },
+                { key: 'name', header: 'NAME' },
+                { key: 'limit', header: 'LIMIT' },
+                { key: 'accessUrl', header: 'ACCESS URL' },
+            ],
+            rows,
+            flags
+        );
+
+        if (flags.qr && !flags.json && !flags.csv) {
+            for (const row of rows) printQr(row.name, row.accessUrl);
+        }
+    },
+
+    async add(client, host, args, flags) {
+        const name = args.join(' ').trim();
+        if (!name) throw new UserError('Please give the new key a name, e.g. add Alice');
+
+        const key = await client.createKey(name);
+        if (flags.limit) {
+            await client.setKeyDataLimit(key.id, parseBytes(flags.limit));
+        }
+
+        const accessUrl = rewriteAccessUrl(key.accessUrl, client.hostname, host);
+        console.log(`Created key "${name}" (id ${key.id})`);
+        if (flags.limit) console.log(`Data limit: ${formatBytes(parseBytes(flags.limit))}`);
+        console.log(accessUrl);
+        if (flags.qr) printQr(name, accessUrl);
+    },
+
+    async remove(client, host, args) {
+        if (!args[0]) throw new UserError('Please say which key to remove, e.g. remove Alice');
+        const key = findKey(await client.listKeys(), args[0]);
+        await client.removeKey(key.id);
+        console.log(`Removed key "${key.name || key.id}" (id ${key.id})`);
+    },
+
+    async rename(client, host, args) {
+        const newName = args.slice(1).join(' ').trim();
+        if (!args[0] || !newName) {
+            throw new UserError('Please give both a key and a new name, e.g. rename Alice Bob');
+        }
+        const key = findKey(await client.listKeys(), args[0]);
+        await client.renameKey(key.id, newName);
+        console.log(`Renamed key ${key.id} from "${key.name || '(unnamed)'}" to "${newName}"`);
+    },
+
+    async limit(client, host, args) {
+        const [target, size] = args;
+        if (!target || !size) {
+            throw new UserError('Please give a key and a size, e.g. limit Alice 10GB (or limit Alice none)');
+        }
+        const clearing = size.toLowerCase() === 'none';
+
+        if (target === 'server') {
+            if (clearing) {
+                await client.clearServerDataLimit();
+                console.log('Cleared the server-wide default data limit.');
+            } else {
+                const bytes = parseBytes(size);
+                await client.setServerDataLimit(bytes);
+                console.log(`Server-wide default data limit set to ${formatBytes(bytes)}.`);
+            }
+            return;
+        }
+
+        const key = findKey(await client.listKeys(), target);
+        if (clearing) {
+            await client.clearKeyDataLimit(key.id);
+            console.log(`Cleared the data limit on "${key.name || key.id}".`);
+        } else {
+            const bytes = parseBytes(size);
+            await client.setKeyDataLimit(key.id, bytes);
+            console.log(`Data limit on "${key.name || key.id}" set to ${formatBytes(bytes)}.`);
+        }
+    },
+
+    async usage(client, host, args, flags) {
+        const [keys, transferred] = await Promise.all([
+            client.listKeys(),
+            client.getTransferMetrics(),
+        ]);
+
+        const rows = keys
+            .map(key => {
+                const bytes = transferred[key.id] || 0;
+                const limitBytes = key.dataLimit ? key.dataLimit.bytes : null;
+                return {
+                    id: key.id,
+                    name: key.name || '(unnamed)',
+                    used: formatBytes(bytes),
+                    limit: limitBytes === null ? '-' : formatBytes(limitBytes),
+                    percent: limitBytes ? Math.round((bytes / limitBytes) * 100) + '%' : '-',
+                    bytes,
+                };
+            })
+            .sort((a, b) => b.bytes - a.bytes);
+
+        output(
+            [
+                { key: 'id', header: 'ID' },
+                { key: 'name', header: 'NAME' },
+                { key: 'used', header: 'USED' },
+                { key: 'limit', header: 'LIMIT' },
+                { key: 'percent', header: 'OF LIMIT' },
+            ],
+            rows,
+            flags
+        );
+
+        if (!flags.json && !flags.csv) {
+            const total = rows.reduce((sum, row) => sum + row.bytes, 0);
+            console.log(`\nTotal transferred: ${formatBytes(total)}`);
+        }
+    },
+
+    async qr(client, host, args) {
+        if (!args[0]) throw new UserError('Please say which key to show, e.g. qr Alice');
+        const key = findKey(await client.listKeys(), args[0]);
+        printQr(key.name || String(key.id), rewriteAccessUrl(key.accessUrl, client.hostname, host));
+    },
 };
 
-getKeys()
-    .then(() => console.log('Completed. These are all you have!'))
-    .catch(err => {
-        console.error('Failed to fetch access keys:', err.message);
-        process.exit(1);
-    });
+async function main() {
+    const { positional, flags } = parseArgs(process.argv.slice(2));
+    const [commandName, ...args] = positional;
+
+    if (flags.help || commandName === 'help') {
+        console.log(USAGE);
+        return;
+    }
+
+    // Listing is the historical default, so bare `node shadowboxKey.js` still works.
+    const command = commands[commandName || 'list'];
+    if (!command) {
+        throw new UserError(`Unknown command "${commandName}". Run with --help to see what is available.`);
+    }
+
+    if (managementApiUrl.includes('xx.xx.xx.xxx')) {
+        throw new UserError(
+            'Please configure your Management API URL first.\n' +
+            'Set the OUTLINE_API_URL environment variable, or edit the managementApiUrl constant in shadowboxKey.js.'
+        );
+    }
+
+    const client = new OutlineClient(managementApiUrl);
+    await command(client, domain || client.hostname, args, flags);
+}
+
+main().catch(err => {
+    console.error(err instanceof UserError ? err.message : `Error: ${err.message}`);
+    process.exit(1);
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { parseArgs, findKey } = require('../shadowboxKey');
+const { UserError } = require('../lib/errors');
+
+test('parseArgs separates positional arguments from flags', () => {
+    const { positional, flags } = parseArgs(['add', 'Alice', '--qr']);
+    assert.deepStrictEqual(positional, ['add', 'Alice']);
+    assert.deepStrictEqual(flags, { qr: true });
+});
+
+test('parseArgs reads the value that follows --limit', () => {
+    const { positional, flags } = parseArgs(['add', 'Alice', '--limit', '50GB']);
+    assert.deepStrictEqual(positional, ['add', 'Alice']);
+    assert.strictEqual(flags.limit, '50GB');
+});
+
+test('parseArgs recognises both spellings of help', () => {
+    assert.strictEqual(parseArgs(['-h']).flags.help, true);
+    assert.strictEqual(parseArgs(['--help']).flags.help, true);
+});
+
+test('parseArgs keeps multi-word names as separate positional arguments', () => {
+    assert.deepStrictEqual(parseArgs(['rename', '0', 'Carol', 'Smith']).positional,
+        ['rename', '0', 'Carol', 'Smith']);
+});
+
+const KEYS = [
+    { id: '0', name: 'Alice' },
+    { id: '1', name: 'Bob' },
+    { id: '2', name: 'bob' },
+    { id: '3', name: '' },
+];
+
+test('findKey matches on id', () => {
+    assert.strictEqual(findKey(KEYS, '0').name, 'Alice');
+    assert.strictEqual(findKey(KEYS, '3').id, '3');
+});
+
+test('findKey matches on exact name', () => {
+    assert.strictEqual(findKey(KEYS, 'Alice').id, '0');
+});
+
+test('findKey prefers an exact name over a case-insensitive one', () => {
+    // Both "Bob" and "bob" exist, so an exact match must win rather than being ambiguous.
+    assert.strictEqual(findKey(KEYS, 'Bob').id, '1');
+    assert.strictEqual(findKey(KEYS, 'bob').id, '2');
+});
+
+test('findKey falls back to a case-insensitive name match', () => {
+    assert.strictEqual(findKey(KEYS, 'ALICE').id, '0');
+});
+
+test('findKey prefers an id over a name that looks like one', () => {
+    const keys = [{ id: '0', name: '1' }, { id: '1', name: 'Bob' }];
+    assert.strictEqual(findKey(keys, '1').name, 'Bob');
+});
+
+test('findKey reports when nothing matches', () => {
+    assert.throws(() => findKey(KEYS, 'Nobody'), UserError);
+});
+
+test('findKey refuses to guess between duplicate names', () => {
+    const keys = [{ id: '0', name: 'Alice' }, { id: '1', name: 'Alice' }];
+    assert.throws(() => findKey(keys, 'Alice'), /matches more than one key/);
+});

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { formatBytes, parseBytes, rewriteAccessUrl, printTable, printCsv } = require('../lib/format');
+const { UserError } = require('../lib/errors');
+
+const KB = 1024;
+const MB = 1024 ** 2;
+const GB = 1024 ** 3;
+const TB = 1024 ** 4;
+
+test('formatBytes renders each unit', () => {
+    assert.strictEqual(formatBytes(0), '0 B');
+    assert.strictEqual(formatBytes(512), '512 B');
+    assert.strictEqual(formatBytes(1.5 * KB), '1.5 KB');
+    assert.strictEqual(formatBytes(512 * MB), '512 MB');
+    assert.strictEqual(formatBytes(3 * GB), '3.0 GB');
+    assert.strictEqual(formatBytes(2 * TB), '2.0 TB');
+});
+
+test('formatBytes drops decimals once the value reaches 10', () => {
+    assert.strictEqual(formatBytes(9.5 * GB), '9.5 GB');
+    assert.strictEqual(formatBytes(10 * GB), '10 GB');
+});
+
+test('formatBytes treats missing values as zero', () => {
+    assert.strictEqual(formatBytes(undefined), '0 B');
+    assert.strictEqual(formatBytes(null), '0 B');
+});
+
+test('parseBytes understands unit suffixes, spacing and case', () => {
+    assert.strictEqual(parseBytes('10GB'), 10 * GB);
+    assert.strictEqual(parseBytes('500 MB'), 500 * MB);
+    assert.strictEqual(parseBytes('2tb'), 2 * TB);
+    assert.strictEqual(parseBytes('1.5GB'), 1.5 * GB);
+    assert.strictEqual(parseBytes(' 4 kb '), 4 * KB);
+});
+
+test('parseBytes accepts a plain byte count', () => {
+    assert.strictEqual(parseBytes('1024'), 1024);
+    assert.strictEqual(parseBytes('900B'), 900);
+});
+
+test('parseBytes rejects input it cannot understand', () => {
+    for (const bad of ['10QQ', 'lots', '', 'GB', '1.2.3GB', '-5GB']) {
+        assert.throws(() => parseBytes(bad), UserError, `expected "${bad}" to be rejected`);
+    }
+});
+
+test('parseBytes and formatBytes round-trip', () => {
+    for (const size of ['10GB', '500MB', '2TB', '750KB']) {
+        assert.strictEqual(formatBytes(parseBytes(size)).replace(/\.0 | /, ''), size);
+    }
+});
+
+test('rewriteAccessUrl swaps the host and keeps port, query and fragment', () => {
+    assert.strictEqual(
+        rewriteAccessUrl('ss://abc@1.2.3.4:443/?outline=1', '1.2.3.4', 'vpn.example.com'),
+        'ss://abc@vpn.example.com:443/?outline=1'
+    );
+    assert.strictEqual(
+        rewriteAccessUrl('ss://abc@1.2.3.4:8388/?outline=1#Alice', '1.2.3.4', 'vpn.example.com'),
+        'ss://abc@vpn.example.com:8388/?outline=1#Alice'
+    );
+});
+
+test('rewriteAccessUrl leaves the URL alone when there is nothing to change', () => {
+    const url = 'ss://abc@1.2.3.4:443/?outline=1';
+    assert.strictEqual(rewriteAccessUrl(url, '1.2.3.4', '1.2.3.4'), url);
+    assert.strictEqual(rewriteAccessUrl(undefined, '1.2.3.4', 'vpn.example.com'), undefined);
+});
+
+test('rewriteAccessUrl does not touch a host appearing elsewhere in the URL', () => {
+    // The host also appears in the base64 payload; only the @host: occurrence should change.
+    assert.strictEqual(
+        rewriteAccessUrl('ss://MS4yLjMuNA@1.2.3.4:443/?outline=1', '1.2.3.4', 'example.com'),
+        'ss://MS4yLjMuNA@example.com:443/?outline=1'
+    );
+});
+
+/** Runs fn with console.log captured, returning the lines it printed. */
+function captureOutput(fn) {
+    const lines = [];
+    const original = console.log;
+    console.log = (...args) => lines.push(args.join(' '));
+    try {
+        fn();
+    } finally {
+        console.log = original;
+    }
+    return lines;
+}
+
+const COLUMNS = [
+    { key: 'id', header: 'ID' },
+    { key: 'name', header: 'NAME' },
+];
+
+test('printTable aligns columns and underlines the header', () => {
+    const lines = captureOutput(() =>
+        printTable(COLUMNS, [{ id: '0', name: 'Alice' }, { id: '10', name: 'Bo' }])
+    );
+    assert.deepStrictEqual(lines, [
+        'ID  NAME',
+        '--  -----',
+        '0   Alice',
+        '10  Bo',
+    ]);
+});
+
+test('printTable says so when there is nothing to show', () => {
+    assert.deepStrictEqual(captureOutput(() => printTable(COLUMNS, [])), ['(none)']);
+});
+
+test('printCsv quotes fields containing commas, quotes or newlines', () => {
+    const lines = captureOutput(() =>
+        printCsv(COLUMNS, [
+            { id: '0', name: 'Smith, Alice' },
+            { id: '1', name: 'He said "hi"' },
+            { id: '2', name: 'two\nlines' },
+            { id: '3', name: undefined },
+        ])
+    );
+    assert.deepStrictEqual(lines, [
+        'ID,NAME',
+        '0,"Smith, Alice"',
+        '1,"He said ""hi"""',
+        '2,"two\nlines"',
+        '3,',
+    ]);
+});


### PR DESCRIPTION
Grows the single-purpose listing script into a command-line tool over the Outline Management API, and tidies up the repository around it.

## Features

| Command | What it does |
| --- | --- |
| `list` | Keys with id, name, data limit and access URL |
| `add <name>` | Create a key (`--limit 50GB` to cap it immediately) |
| `remove <key>` | Delete a key |
| `rename <key> <new name>` | Rename a key |
| `limit <key> <size\|none>` | Set or clear a per-key data cap |
| `limit server <size\|none>` | Set or clear the server-wide default cap |
| `usage` | Bytes transferred per key, with percentage against each cap |
| `qr <key>` | Print the access URL as a scannable QR code |

Keys are addressable by either id or name, so `remove Alice` works as well as `remove 0`. Sizes accept unit suffixes (`10GB`, `500MB`, `2TB`). `--qr` adds QR codes to `list` and `add`; `--json` and `--csv` switch the output format for `list` and `usage`.

## Repository housekeeping

- **README** rewritten from four lines into full documentation: prerequisites, installation, configuration, the command and option reference, worked examples with real output, project layout, a note on the self-signed-certificate handling, and troubleshooting.
- **Configuration via environment variables** (`OUTLINE_API_URL`, `OUTLINE_DOMAIN`), so the Management API URL — which grants full admin control of the server — no longer has to live in a tracked file. The editable constants still work as a fallback.
- **`node-fetch` bumped 2.6.0 → 2.7.0**, which resolves the two Dependabot alerts currently open on `master`. `npm audit` is clean.
- **`package.json`** filled out with a description, `start` script, `bin` entry, keywords, repository and engine fields; the invalid uppercase package name is fixed.
- **`.gitignore`** extended to cover `.env` files, editor directories and OS artifacts.

## Structure

The entry point was getting long, so the pieces are split out:

```
shadowboxKey.js    argument parsing and command bodies
lib/outline.js     Outline Management API client
lib/format.js      byte parsing/formatting, table and CSV output
lib/errors.js      UserError, printed without a stack trace
```

## Compatibility

Running `node shadowboxKey.js` with no arguments still just lists keys, as before. One deliberate behaviour change: access URLs now keep their `/?outline=1` suffix instead of having it stripped, since Outline clients use that marker.

## Testing

Verified against a mock Outline Management API (self-signed HTTPS, real endpoint shapes and 204-no-content responses): create, rename, set limit, clear limit, server-wide limit, usage, remove, QR rendering, all three output formats, and the error paths — unknown key, ambiguous name, unknown command, unparseable size, missing arguments. All behave correctly and exit non-zero on failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJR2DDBimsijgYgZS3bUS8)_