### PR TITLE
Replace node-fetch with the built-in node:https module

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,15 @@ Every push and pull request runs the suite on Node 18, 20 and 22 via GitHub Acti
 
 Outline servers use a self-signed TLS certificate for the Management API, so the tool disables certificate verification (`rejectUnauthorized: false`) for those requests. This is normal for the Outline Management API, but it does mean the connection is not protected against man-in-the-middle attacks. Only run this against servers you control, ideally from a trusted network.
 
+This is also why the HTTP calls use the built-in `node:https` module rather than the global `fetch()`: `fetch` has no supported way to relax certificate checks for a single request — it ignores the `agent` option, and its dispatcher lives in `undici`, which would mean taking on a dependency to do what `node:https` already does.
+
 ## Troubleshooting
 
 - **`Please configure your Management API URL first`** — set `OUTLINE_API_URL`, or replace the placeholder in `shadowboxKey.js`.
 - **`Could not reach the Outline server`** — check that the Management API URL is correct and that its port (usually `16942`) is reachable from your machine.
-- **`Cannot find module 'node-fetch'`** — run `npm install` in the project directory first.
+- **`Cannot find module 'qrcode-terminal'`** — run `npm install` in the project directory first.
 - **`Management API responded with 404`** — your Outline server may be running an older release that lacks data-limit or metrics endpoints. Upgrade the server, or stick to `list`, `add`, `remove` and `rename`.
 - **Keys print with the IP instead of your domain** — make sure `OUTLINE_DOMAIN` (or the `domain` constant) is set and non-empty.
-- **`DeprecationWarning: The punycode module is deprecated`** — harmless, and emitted by the `node-fetch` dependency on newer Node versions. Silence it with `NODE_NO_WARNINGS=1`.
 
 ## License
 

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -1,13 +1,46 @@
 'use strict';
 
-const fetch = require('node-fetch');
 const https = require('https');
 const { UserError } = require('./errors');
 
 // Outline's Management API is served with a self-signed certificate, so
 // certificate verification has to be disabled. Only point this client at
 // servers you control.
+//
+// This uses node:https rather than the global fetch() because fetch offers no
+// supported way to relax certificate checks for a single request: it ignores
+// the agent option, and its dispatcher lives in undici, which is not reachable
+// without taking on a dependency.
 const agent = new https.Agent({ rejectUnauthorized: false });
+
+/** Sends one request and resolves with the status line and raw body text. */
+function send(url, method, body) {
+    return new Promise((resolve, reject) => {
+        const options = { method, agent };
+        if (body !== undefined) {
+            options.headers = {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(body),
+            };
+        }
+
+        const req = https.request(url, options, res => {
+            let text = '';
+            res.setEncoding('utf8');
+            res.on('data', chunk => (text += chunk));
+            res.on('end', () => resolve({
+                status: res.statusCode,
+                statusText: res.statusMessage || '',
+                text,
+            }));
+            res.on('error', reject);
+        });
+
+        req.on('error', reject);
+        if (body !== undefined) req.write(body);
+        req.end();
+    });
+}
 
 class OutlineClient {
     constructor(managementApiUrl) {
@@ -16,30 +49,29 @@ class OutlineClient {
     }
 
     async request(method, path, body) {
-        const options = { method, agent };
-        if (body !== undefined) {
-            options.body = JSON.stringify(body);
-            options.headers = { 'Content-Type': 'application/json' };
-        }
+        const payload = body === undefined ? undefined : JSON.stringify(body);
 
         let response;
         try {
-            response = await fetch(this.baseUrl + path, options);
+            response = await send(this.baseUrl + path, method, payload);
         } catch (err) {
             throw new UserError(`Could not reach the Outline server: ${err.message}`);
         }
 
-        if (!response.ok) {
+        if (response.status < 200 || response.status >= 300) {
             throw new UserError(
                 `Management API responded with ${response.status} ${response.statusText} for ${method} ${path}`
             );
         }
 
-        // 204 No Content, which most write endpoints return.
-        if (response.status === 204) return null;
+        // Write endpoints answer 204 No Content, so there is nothing to parse.
+        if (!response.text) return null;
 
-        const text = await response.text();
-        return text ? JSON.parse(text) : null;
+        try {
+            return JSON.parse(response.text);
+        } catch (err) {
+            throw new UserError(`Could not read the response from ${method} ${path}: ${err.message}`);
+        }
     }
 
     async listKeys() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,38 +1,20 @@
 {
   "name": "shadowbox-keys",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shadowbox-keys",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "dependencies": {
-        "node-fetch": "^2.7.0",
         "qrcode-terminal": "^0.12.0"
       },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+      "bin": {
+        "shadowbox-keys": "shadowboxKey.js"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+        "node": ">=14"
       }
     },
     "node_modules/qrcode-terminal": {
@@ -41,28 +23,6 @@
       "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "node": ">=14"
   },
   "dependencies": {
-    "node-fetch": "^2.7.0",
     "qrcode-terminal": "^0.12.0"
   }
 }


### PR DESCRIPTION
Drops the last HTTP dependency, leaving `qrcode-terminal` as the only runtime dependency.

## Why `node:https` rather than the global `fetch()`

The obvious move is native `fetch`, but it cannot do this job. Outline's Management API is served with a self-signed certificate, and `fetch` offers no supported way to relax certificate checks for a single request. Verified against a local self-signed server:

| Approach | Result |
| --- | --- |
| Plain `fetch()` | fails with `DEPTH_ZERO_SELF_SIGNED_CERT` |
| `fetch()` with `{ agent: new https.Agent({ rejectUnauthorized: false }) }` | same failure — `agent` was a node-fetch extension, native `fetch` ignores it |
| `fetch()` with an undici dispatcher | would require adding `undici`, swapping one dependency for another |
| `node:https` with the same agent | works |

The remaining alternative, `NODE_TLS_REJECT_UNAUTHORIZED=0`, disables verification process-wide rather than for this one host, which is strictly worse than the current behaviour.

Using `node:https` also keeps the Node 14 floor that native `fetch` would have raised to 18.

## Changes

- `lib/outline.js` performs its requests through `node:https`, wrapped in a small promise helper; the client's public surface is unchanged.
- `node-fetch` removed from `package.json` and the lockfile.
- README explains the choice in the TLS section, and its troubleshooting entry for the `punycode` deprecation warning is gone along with the warning itself.

## Behaviour

Identical: same requests, same error messages. Two incidental improvements fall out of it — a malformed response body now reports as `Could not read the response from …` instead of a raw `SyntaxError`, and the `punycode` deprecation warning that node-fetch emitted on recent Node versions no longer appears.

## Testing

All 24 unit tests pass. Re-ran the CLI end-to-end against a mock Management API covering every verb the client uses: GET for `list` and metrics, POST for key creation, PUT with a JSON body for renames and data limits, and DELETE with 204 No Content for key and limit removal. Error paths verified too — an unreachable host and a 404 from the API both print cleanly and exit non-zero.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJR2DDBimsijgYgZS3bUS8)_