### PR TITLE
Add optional TLS certificate pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,26 @@ npm install
 
 ## Configuration
 
-Configure the tool either with environment variables (recommended — keeps secrets out of the code) or by editing the two constants at the top of `shadowboxKey.js`.
+Configure the tool either with environment variables (recommended — keeps secrets out of the code) or by editing the constants at the top of `shadowboxKey.js`.
 
 | Setting | Environment variable | Description |
 | --- | --- | --- |
 | Management API URL | `OUTLINE_API_URL` | The Management API URL copied from Outline Manager. **Required.** |
+| Certificate fingerprint | `OUTLINE_CERT_SHA256` | The server's `certSha256`. Optional but **recommended** — see [certificate pinning](#certificate-pinning). |
 | Custom domain | `OUTLINE_DOMAIN` | A domain that points at your Outline server. Optional — leave empty to keep the raw IP in the access URLs. |
+
+Outline Manager gives you the first two together. Under **Settings → Management API URL** it shows a line like:
+
+```json
+{"apiUrl":"https://1.2.3.4:16942/AbCdEf123","certSha256":"E3823F9BB490D354...52F5A584"}
+```
 
 A convenient way to keep these out of your shell history is a `.env` file (already git-ignored) that you source before running:
 
 ```bash
 # .env
 export OUTLINE_API_URL="https://1.2.3.4:16942/AbCdEf123"
+export OUTLINE_CERT_SHA256="E3823F9BB490D354...52F5A584"
 export OUTLINE_DOMAIN="vpn.example.com"
 ```
 
@@ -145,17 +153,40 @@ The tests cover the pure logic — size parsing and formatting, access-URL rewri
 
 Every push and pull request runs the suite on Node 18, 20 and 22 via GitHub Actions, along with a syntax check and an audit of production dependencies. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
-## A note on TLS verification
+## Certificate pinning
 
-Outline servers use a self-signed TLS certificate for the Management API, so the tool disables certificate verification (`rejectUnauthorized: false`) for those requests. This is normal for the Outline Management API, but it does mean the connection is not protected against man-in-the-middle attacks. Only run this against servers you control, ideally from a trusted network.
+Outline servers use a self-signed TLS certificate for the Management API, so the usual chain validation cannot apply and the tool disables it (`rejectUnauthorized: false`). On its own that would leave the connection open to a man-in-the-middle: anything that can answer on the server's address would be trusted.
 
-This is also why the HTTP calls use the built-in `node:https` module rather than the global `fetch()`: `fetch` has no supported way to relax certificate checks for a single request — it ignores the `agent` option, and its dispatcher lives in `undici`, which would mean taking on a dependency to do what `node:https` already does.
+Setting `OUTLINE_CERT_SHA256` closes that gap. The tool then checks the certificate the server presents against the fingerprint you configured, and **aborts before sending anything** if they differ:
+
+```console
+$ OUTLINE_CERT_SHA256=aaaa...aaaa node shadowboxKey.js list
+The server presented an unexpected TLS certificate, so the request was not sent.
+  expected: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  received: e3823f9bb490d35487ee013ec7d23a3662f76b95eb01a40f4851905152f5a584
+Check OUTLINE_CERT_SHA256 against certSha256 in Outline Manager. If it has not
+changed there, you may be talking to the wrong server.
+```
+
+The check runs at the end of the TLS handshake, before any request bytes leave your machine. That ordering matters: the path in the Management API URL *is* the admin credential, so it must never be sent to a server that hasn't been authenticated.
+
+The fingerprint is accepted in either form — the bare hex Outline Manager reports as `certSha256`, or the colon-separated form `openssl x509 -noout -fingerprint -sha256` prints — in any case.
+
+Pinning is optional for backwards compatibility. Leave `OUTLINE_CERT_SHA256` unset and the tool behaves as before, connecting without verifying which server answered. Set it whenever you can, especially on an untrusted network.
+
+If you rebuild or migrate your server, its certificate changes; copy the new `certSha256` from Outline Manager.
+
+### Why `node:https` rather than `fetch()`
+
+The HTTP calls use the built-in `node:https` module because the global `fetch()` has no supported way to relax certificate checks or inspect the peer certificate for a single request — it ignores the `agent` option, and its dispatcher lives in `undici`, which would mean taking on a dependency to do what `node:https` already does.
 
 ## Troubleshooting
 
 - **`Please configure your Management API URL first`** — set `OUTLINE_API_URL`, or replace the placeholder in `shadowboxKey.js`.
 - **`Could not reach the Outline server`** — check that the Management API URL is correct and that its port (usually `16942`) is reachable from your machine.
 - **`Cannot find module 'qrcode-terminal'`** — run `npm install` in the project directory first.
+- **`The server presented an unexpected TLS certificate`** — either `OUTLINE_CERT_SHA256` is stale (recopy `certSha256` from Outline Manager after rebuilding or migrating the server), or something other than your Outline server answered. See [certificate pinning](#certificate-pinning).
+- **`is not a SHA-256 certificate fingerprint`** — `OUTLINE_CERT_SHA256` must be 64 hex characters, with or without colons.
 - **`Management API responded with 404`** — your Outline server may be running an older release that lacks data-limit or metrics endpoints. Upgrade the server, or stick to `list`, `add`, `remove` and `rename`.
 - **Keys print with the IP instead of your domain** — make sure `OUTLINE_DOMAIN` (or the `domain` constant) is set and non-empty.
 

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -13,8 +13,56 @@ const { UserError } = require('./errors');
 // without taking on a dependency.
 const agent = new https.Agent({ rejectUnauthorized: false });
 
+/**
+ * Normalises a SHA-256 certificate fingerprint to bare lowercase hex, accepting
+ * the colon-separated form openssl prints as well as the plain form Outline
+ * Manager reports as certSha256. Returns null for empty input.
+ */
+function normalizeFingerprint(value) {
+    if (!value) return null;
+    const hex = String(value).replace(/[:\s]/g, '').toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(hex)) {
+        throw new UserError(
+            `"${value}" is not a SHA-256 certificate fingerprint. ` +
+            'Expected 64 hex characters, as shown by certSha256 in Outline Manager.'
+        );
+    }
+    return hex;
+}
+
+/**
+ * Aborts the request unless the server presented the certificate we expect.
+ *
+ * The check runs on secureConnect, before any request bytes leave the process,
+ * because the Management API URL's path component is itself the admin secret
+ * and must not be sent to a server we have not authenticated.
+ */
+function pinCertificate(req, socket, expected) {
+    const verify = () => {
+        const cert = socket.getPeerCertificate();
+        const actual = cert && cert.fingerprint256
+            ? cert.fingerprint256.replace(/:/g, '').toLowerCase()
+            : null;
+
+        if (actual !== expected) {
+            req.destroy(new UserError(
+                'The server presented an unexpected TLS certificate, so the request was not sent.\n' +
+                `  expected: ${expected}\n` +
+                `  received: ${actual || '(none)'}\n` +
+                'Check OUTLINE_CERT_SHA256 against certSha256 in Outline Manager. If it has not ' +
+                'changed there, you may be talking to the wrong server.'
+            ));
+        }
+    };
+
+    // A pooled socket has already completed its handshake; a fresh one has not.
+    const cert = socket.getPeerCertificate && socket.getPeerCertificate();
+    if (cert && cert.fingerprint256) verify();
+    else socket.once('secureConnect', verify);
+}
+
 /** Sends one request and resolves with the status line and raw body text. */
-function send(url, method, body) {
+function send(url, method, body, fingerprint) {
     return new Promise((resolve, reject) => {
         const options = { method, agent };
         if (body !== undefined) {
@@ -36,6 +84,10 @@ function send(url, method, body) {
             res.on('error', reject);
         });
 
+        if (fingerprint) {
+            req.on('socket', socket => pinCertificate(req, socket, fingerprint));
+        }
+
         req.on('error', reject);
         if (body !== undefined) req.write(body);
         req.end();
@@ -43,9 +95,10 @@ function send(url, method, body) {
 }
 
 class OutlineClient {
-    constructor(managementApiUrl) {
+    constructor(managementApiUrl, certSha256) {
         this.baseUrl = managementApiUrl.replace(/\/+$/, '');
         this.hostname = new URL(this.baseUrl).hostname;
+        this.fingerprint = normalizeFingerprint(certSha256);
     }
 
     async request(method, path, body) {
@@ -53,8 +106,10 @@ class OutlineClient {
 
         let response;
         try {
-            response = await send(this.baseUrl + path, method, payload);
+            response = await send(this.baseUrl + path, method, payload, this.fingerprint);
         } catch (err) {
+            // A pinning failure is already a clear message; don't bury it.
+            if (err instanceof UserError) throw err;
             throw new UserError(`Could not reach the Outline server: ${err.message}`);
         }
 
@@ -120,4 +175,4 @@ class OutlineClient {
     }
 }
 
-module.exports = { OutlineClient };
+module.exports = { OutlineClient, normalizeFingerprint };

--- a/shadowboxKey.js
+++ b/shadowboxKey.js
@@ -6,6 +6,7 @@
 // so the Management API URL never ends up committed to version control.
 const managementApiUrl = process.env.OUTLINE_API_URL || 'https://xx.xx.xx.xxx:16942/xxxxxxxxxxxxxxxxxxxxxx'; // Management API URL from Outline Manager > Settings
 const domain = process.env.OUTLINE_DOMAIN || ''; // set your custom domain if you have one, e.g. 'vpn.example.com'
+const certSha256 = process.env.OUTLINE_CERT_SHA256 || ''; // recommended: certSha256 from Outline Manager, to pin the server's certificate
 // END Variables to change
 
 const qrcode = require('qrcode-terminal');
@@ -39,8 +40,11 @@ Options:
 Sizes accept a unit suffix, e.g. 10GB, 500MB, 2TB.
 
 Configuration (environment variables):
-  OUTLINE_API_URL   Management API URL from Outline Manager > Settings
-  OUTLINE_DOMAIN    Optional custom domain to use in place of the server IP
+  OUTLINE_API_URL      Management API URL from Outline Manager > Settings
+  OUTLINE_DOMAIN       Optional custom domain to use in place of the server IP
+  OUTLINE_CERT_SHA256  Recommended. The server's certSha256, from the same place
+                       in Outline Manager. When set, the tool refuses to talk to
+                       any server presenting a different certificate.
 
 Examples:
   node shadowboxKey.js list --qr
@@ -257,7 +261,7 @@ async function main() {
         );
     }
 
-    const client = new OutlineClient(managementApiUrl);
+    const client = new OutlineClient(managementApiUrl, certSha256);
     await command(client, domain || client.hostname, args, flags);
 }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -4,6 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const { parseArgs, findKey } = require('../shadowboxKey');
+const { OutlineClient, normalizeFingerprint } = require('../lib/outline');
 const { UserError } = require('../lib/errors');
 
 test('parseArgs separates positional arguments from flags', () => {
@@ -66,4 +67,39 @@ test('findKey reports when nothing matches', () => {
 test('findKey refuses to guess between duplicate names', () => {
     const keys = [{ id: '0', name: 'Alice' }, { id: '1', name: 'Alice' }];
     assert.throws(() => findKey(keys, 'Alice'), /matches more than one key/);
+});
+
+const FINGERPRINT = 'e3823f9bb490d35487ee013ec7d23a3662f76b95eb01a40f4851905152f5a584';
+
+test('normalizeFingerprint accepts the colon-separated form openssl prints', () => {
+    const withColons = FINGERPRINT.toUpperCase().replace(/(..)(?=.)/g, '$1:');
+    assert.strictEqual(normalizeFingerprint(withColons), FINGERPRINT);
+});
+
+test('normalizeFingerprint accepts the bare form Outline Manager reports', () => {
+    assert.strictEqual(normalizeFingerprint(FINGERPRINT), FINGERPRINT);
+    assert.strictEqual(normalizeFingerprint(FINGERPRINT.toUpperCase()), FINGERPRINT);
+});
+
+test('normalizeFingerprint treats an unset value as no pinning', () => {
+    assert.strictEqual(normalizeFingerprint(''), null);
+    assert.strictEqual(normalizeFingerprint(undefined), null);
+});
+
+test('normalizeFingerprint rejects anything that is not a SHA-256 digest', () => {
+    const tooShort = FINGERPRINT.slice(0, 62);
+    const notHex = 'z'.repeat(64);
+    for (const bad of ['nonsense', tooShort, FINGERPRINT + 'ab', notHex]) {
+        assert.throws(() => normalizeFingerprint(bad), UserError, `expected "${bad}" to be rejected`);
+    }
+});
+
+test('the client rejects a bad fingerprint at construction, before any request', () => {
+    assert.throws(() => new OutlineClient('https://1.2.3.4:16942/abc', 'nonsense'), UserError);
+});
+
+test('the client stores a normalised fingerprint, and none when unset', () => {
+    const url = 'https://1.2.3.4:16942/abc';
+    assert.strictEqual(new OutlineClient(url, FINGERPRINT.toUpperCase()).fingerprint, FINGERPRINT);
+    assert.strictEqual(new OutlineClient(url).fingerprint, null);
 });


### PR DESCRIPTION
Closes the man-in-the-middle gap the README has been warning about.

## The problem

Outline's Management API is served with a self-signed certificate, so ordinary chain validation cannot apply and the client disables it (`rejectUnauthorized: false`). On its own that means anything able to answer on the server's address is trusted — and the path component of the Management API URL is the admin credential, so a wrong answer is an expensive one.

## The fix

Set `OUTLINE_CERT_SHA256` to the server's `certSha256` (Outline Manager shows it next to the API URL). The client then compares the certificate the server presents against that fingerprint and aborts if they differ:

```console
$ OUTLINE_CERT_SHA256=aaaa...aaaa node shadowboxKey.js list
The server presented an unexpected TLS certificate, so the request was not sent.
  expected: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
  received: e3823f9bb490d35487ee013ec7d23a3662f76b95eb01a40f4851905152f5a584
Check OUTLINE_CERT_SHA256 against certSha256 in Outline Manager. If it has not
changed there, you may be talking to the wrong server.
```

The check runs on `secureConnect`, at the end of the TLS handshake and **before any request bytes are written**. That ordering is the point of the change: aborting after the request has been sent would already have handed the admin path to the impostor.

Pinning stays optional. Leaving the variable unset preserves the current behaviour exactly, so this breaks no existing setup.

## Testing

Six unit tests cover fingerprint normalisation (bare and colon-separated, any case), rejection of malformed values, and that a bad fingerprint fails at client construction rather than mid-request. Suite is 30 tests, all passing.

The behaviour that matters was verified end to end against a mock Management API:

| Scenario | Result |
| --- | --- |
| Correct fingerprint, either format | all commands work normally |
| Wrong fingerprint, read command | aborted; server log shows no request arrived |
| Wrong fingerprint, write commands (`add`, `remove`, `limit server`) | aborted; no request or body arrived, server state unchanged |
| Impostor server holding a *different valid* certificate | connection refused, impostor received nothing |
| Same impostor, pinning unset | request would have completed — the gap this closes |
| Malformed fingerprint | clear error, exits non-zero, no connection attempted |

## Docs

The README's "A note on TLS verification" section becomes "Certificate pinning": what the exposure is, how to configure it, why the check happens before the request, and that a rebuilt or migrated server needs its new `certSha256` copied over. Two troubleshooting entries added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJR2DDBimsijgYgZS3bUS8)_