### PR TITLE
Run the tests before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "start": "node shadowtools.js",
-    "test": "node --test"
+    "test": "node --test",
+    "prepublishOnly": "npm test"
   },
   "keywords": [
     "outline",


### PR DESCRIPTION
Adds a `prepublishOnly` guard so `npm publish` fails rather than ships a broken build.

```json
"prepublishOnly": "npm test"
```

## Verified, not assumed

A guard that does not actually block is worse than none, so I checked all three behaviours it needs:

| Behaviour | Result |
| --- | --- |
| Runs on `npm publish` | `> shadowtools@4.0.0 prepublishOnly` → `npm test` → `# pass 62` |
| Aborts the publish when a test fails | Added a deliberately failing test: `npm error code 1`, exit 1, nothing published |
| Does **not** block `npm pack` | Tarball still builds — packing is not publishing |

The temporary failing test was removed afterwards; the suite is back to 62 passing.

## Why it is worth the one line

The package is about to go to npm for the first time. Publishing is close to irreversible — npm restricts unpublishing after 72 hours and the name stays claimed either way — so the cost of shipping a broken version is much higher than for a normal commit. CI already covers pushes and pull requests, but nothing stood between a local working copy and the registry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJR2DDBimsijgYgZS3bUS8)_