### PR TITLE
Publish from CI on a GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+# Publishes to npm when a GitHub Release is published, so shipping a version is
+# "tag and release" rather than someone running npm publish from a laptop.
+#
+# Authentication uses npm trusted publishing (OIDC): GitHub Actions proves its
+# identity to the registry directly, so there is no long-lived token stored in
+# repository secrets or on anyone's machine. It requires a one-time setup on
+# npmjs.com — see "Releasing" in the README.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for OIDC. Without it the registry has nothing to verify.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      # Trusted publishing needs npm 11.5.1 or newer, which is more recent than
+      # the npm bundled with some Node versions. The printed version makes it
+      # obvious in the log if this ever regresses.
+      - name: Use an npm that supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      - name: Install dependencies
+        run: npm ci
+
+      # A release tagged v1.2.3 must publish 1.2.3. Catching a mismatch here
+      # costs seconds; catching it afterwards is not possible, because a
+      # published npm version can never be replaced.
+      - name: Check the tag matches package.json
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          if [ "${TAG#v}" != "$version" ]; then
+            echo "::error::Release tag '$TAG' does not match package.json version '$version'."
+            echo "Bump the version and retag, or delete and recreate the release." >&2
+            exit 1
+          fi
+          echo "Publishing $version from tag $TAG."
+
+      # The tests run through the prepublishOnly hook, so a failing suite stops
+      # the publish. Trusted publishing attests provenance automatically, so no
+      # --provenance flag is needed.
+      - name: Publish
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -274,6 +274,39 @@ The tests cover the pure logic — size parsing and formatting, access-URL rewri
 
 Every push and pull request runs the suite on Node 18, 20 and 22 via GitHub Actions, along with a syntax check and an audit of production dependencies. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
+## Releasing
+
+Releases publish from CI, so no npm token exists on anyone's machine or in
+repository secrets. Authentication uses npm
+[trusted publishing](https://docs.npmjs.com/trusted-publishers): GitHub Actions
+proves its identity to the registry over OIDC, and npm attests the package's
+provenance automatically.
+
+To ship a version:
+
+```bash
+npm version minor        # or patch / major - commits and tags
+git push --follow-tags
+```
+
+Then publish a GitHub Release for that tag. [`release.yml`](.github/workflows/release.yml)
+installs, verifies the tag matches `package.json`, runs the tests through the
+`prepublishOnly` hook, and publishes. A tag that disagrees with the version
+fails before anything reaches the registry, which matters because a published
+npm version can never be replaced.
+
+### One-time setup
+
+Trusted publishing has to be enabled on the registry side once, by a package
+maintainer:
+
+1. Open the package on npmjs.com, then **Settings → Trusted Publisher**.
+2. Choose GitHub Actions and enter the organization (`rahmanow`), the repository
+   (`shadowtools`), and the workflow filename (`release.yml`).
+
+Until that is configured, the workflow's publish step fails with an
+authentication error — which is the safe direction to fail in.
+
 ## Certificate pinning
 
 Outline servers use a self-signed TLS certificate for the Management API, so the usual chain validation cannot apply and the tool disables it (`rejectUnauthorized: false`). On its own that would leave the connection open to a man-in-the-middle: anything that can answer on the server's address would be trusted.


### PR DESCRIPTION
Shipping a version becomes tag-and-release, instead of someone running `npm publish` from a laptop.

```bash
npm version minor
git push --follow-tags
```

Then publish a GitHub Release for the tag. The workflow installs, checks the tag, runs the tests, and publishes.

## No token, anywhere

Authentication uses npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) over OIDC: GitHub Actions proves its identity to the registry directly. There is **no long-lived token** — not in repository secrets, not on anyone's machine — and npm attests the package's provenance automatically, so no `--provenance` flag is needed.

That drove two details in the workflow:

- **`id-token: write`**, scoped to the publish job. Without it the registry has nothing to verify.
- **`npm install -g npm@latest`** before publishing. Trusted publishing needs npm 11.5.1 or newer, which is more recent than the npm bundled with some Node versions. The step prints the version so a regression is visible in the log rather than silent.

## Two guards before anything reaches the registry

**Tag must match `package.json`.** A release tagged `v1.2.3` publishing `1.2.3` is the only accepted combination. This matters more than a usual check because a published npm version can never be replaced — catching a mismatch afterwards is not an option. I tested the logic both ways: `v4.0.0` and `4.0.0` pass against version `4.0.0`; `v5.0.0` and `release-4.0.0` fail with a non-zero exit.

The tag is passed through an environment variable rather than interpolated into the shell, so a crafted tag name cannot inject commands.

**Tests must pass.** They run through the existing `prepublishOnly` hook from #10, so a failing suite stops the publish without the workflow needing its own test step.

## One-time setup needed before this works

Trusted publishing has to be enabled on the registry side, which only a package maintainer can do:

1. Open `shadowtools` on npmjs.com → **Settings → Trusted Publisher**
2. GitHub Actions, organization `rahmanow`, repository `shadowtools`, workflow `release.yml`

Until that exists, the publish step fails with an authentication error — the safe direction to fail in. The README's new **Releasing** section documents both this and the release steps.

## What I could not verify

I tested the YAML parses, the tag guard's logic, and that the workflow file is excluded from the published tarball. **I could not test the OIDC handshake itself** — that only exercises on a real release, against a registry configured with the Trusted Publisher entry above. If the first release fails on authentication, that is where to look.

Also worth knowing: npm's own documentation is blocked by this environment's network policy, so the specifics above come from the GitHub changelog announcement and community write-ups rather than from npmjs.com directly. Worth a glance at [the docs](https://docs.npmjs.com/trusted-publishers) when you configure it.

## A deliberate inconsistency

This workflow pins `actions/checkout@v5` and `actions/setup-node@v5`, while `ci.yml` still uses `@v4` — which GitHub currently warns about, since v4 targets the deprecated Node 20 runtime. I left `ci.yml` alone to keep this PR to one concern. Bumping it is a two-line follow-up whenever you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJR2DDBimsijgYgZS3bUS8)_