### PR TITLE
Bump CI actions to v5 and add an npm badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         node: ['18', '20', '22']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -55,9 +55,9 @@ jobs:
     name: Dependency audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # shadowtools
 
 [![CI](https://github.com/rahmanow/shadowtools/actions/workflows/ci.yml/badge.svg)](https://github.com/rahmanow/shadowtools/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/shadowtools.svg)](https://www.npmjs.com/package/shadowtools)
 
 Manage access keys on your [Outline VPN](https://getoutline.org/) (Shadowbox) server, from the terminal, a local web interface, or your own code. It lists, creates, renames and deletes keys, sets per-key data limits, reports how much data each key has used, and prints scannable QR codes so people can onboard with the Outline app instead of copy-pasting `ss://` strings.
 


### PR DESCRIPTION
Two small follow-ups from #11.

## CI actions to v5

`actions/checkout` and `actions/setup-node` move from `@v4` to `@v5`, in both jobs. GitHub currently prints this on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4

That warning goes away, and `ci.yml` now matches `release.yml`, which #11 introduced on v5 — so the deliberate inconsistency I flagged there is resolved. Both workflows pin the same majors:

```
3  uses: actions/checkout@v5
3  uses: actions/setup-node@v5
```

## npm badge

The README gains a version badge next to the CI one, now that the package is live:

```markdown
[[npm](https://img.shields.io/npm/v/shadowtools.svg)](https://www.npmjs.com/package/shadowtools)
```

One caveat worth stating plainly: **I could not render-test the badge.** `img.shields.io` is blocked by this environment's network policy, so the request fails outright from here. What I did verify is the data behind it — `registry.npmjs.org/shadowtools` returns `4.0.0` as `latest` — and the URL follows shields.io's standard `npm/v/<package>` form. If it renders blank, that is where to look.

## Testing

Both workflows parse, 62 tests pass, and the action versions are consistent across the two files. The real check on the `@v5` bump is this PR's own CI run, since it exercises the bumped actions directly — worth confirming the deprecation warning is gone from the log.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJR2DDBimsijgYgZS3bUS8)_