### PR TITLE
4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shadowbox-keys",
-  "version": "2.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shadowbox-keys",
-      "version": "2.0.0",
+      "version": "4.0.1",
       "dependencies": {
         "qrcode-terminal": "^0.12.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shadowtools",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Manage Outline VPN (Shadowbox) access keys from the command line or from code: list, create, rename, delete, set data limits, report usage and print QR codes",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
A no-op patch release, to sync the npm package page and to exercise the release workflow from #11 on a change where nothing can regress.

## Why

`shadowtools@4.0.0` was published by hand, before #11 and #12 landed. npm renders a package's page from the README **inside the published tarball**, so the page is 34 lines behind the repository — missing the npm badge and the whole Releasing section.

The code is not behind. I diffed the published tarball against `master`:

```
=== do the shipped code files differ? ===
(no output = published code matches master)
```

All eight shipped files are byte-identical. Only the README drifted.

## Why now

This is the first release to go through [`release.yml`](.github/workflows/release.yml), and the OIDC handshake is the one part of that workflow that cannot be tested except by running it. A patch whose code cannot change is the best possible thing to find that out on.

## Changes

`package.json` and `package-lock.json` to `4.0.1`, via `npm version patch --no-git-tag-version`. Nothing else.

Once merged I'll tag `v4.0.1` on the merge commit. Publishing the GitHub Release for that tag triggers the workflow, which checks the tag matches `package.json`, runs the tests through `prepublishOnly`, and publishes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJR2DDBimsijgYgZS3bUS8)_