### PR TITLE
4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Notable changes to shadowtools. The format follows
 
 ## [Unreleased]
 
+## [4.1.0] — 2026-08-28
+
+The web interface becomes an admin dashboard that manages servers as well as
+keys, and can run in the background with a URL you can bookmark.
+
 ### Added
 
 - **The web interface is now a multi-server admin dashboard.** It manages the
@@ -153,5 +158,6 @@ They are recorded because the version numbers appear in the git history.
 - The original script: list access keys, rewriting the server IP to a custom
   domain.
 
-[Unreleased]: https://github.com/rahmanow/shadowtools/compare/v4.0.1...HEAD
+[Unreleased]: https://github.com/rahmanow/shadowtools/compare/v4.1.0...HEAD
+[4.1.0]: https://github.com/rahmanow/shadowtools/releases/tag/v4.1.0
 [4.0.1]: https://github.com/rahmanow/shadowtools/releases/tag/v4.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shadowtools",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shadowtools",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "qrcode-terminal": "^0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shadowtools",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Manage Outline VPN (Shadowbox) servers and access keys from a local admin dashboard, the command line, or your own code: list, create, rename, delete, set data limits, report usage and show QR codes",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
Version bump and CHANGELOG for 4.1.0. No code changes — everything shipping here already landed in [#15](https://github.com/rahmanow/shadowtools/pull/15).

**A minor, not a patch.** The CLI gains the `servers` and `service` command families, servers gain somewhere to be saved, and the dashboard URL stops changing between runs. Nothing that worked before behaves differently: `OUTLINE_API_URL` still takes precedence, and a setup that only ever used it is untouched.

## What ships

- The web interface becomes a four-section admin dashboard that manages servers as well as keys, saving access codes pasted from Outline Manager.
- It can run as a background service — launchd on macOS, systemd's user instance on Linux — with a URL you can bookmark.
- Four defects fixed along the way: a redaction that showed short access-code secrets in full, an unbounded Management API request, a `launchctl` race that broke `service restart`, and the dashboard token being written into a world-readable service log.

The full entry is in [CHANGELOG.md](CHANGELOG.md).

## After merging

Tag the merge commit `v4.1.0`, push it, and publish a GitHub Release for that tag. [`release.yml`](.github/workflows/release.yml) verifies the tag matches `package.json`, runs the suite through `prepublishOnly`, and publishes over OIDC.

## Checked before opening this

- 131 tests pass.
- `npm pack --dry-run` ships all 15 files, including the four new `lib/` modules.
- `package-lock.json` bumped alongside `package.json` (via `npm version --no-git-tag-version`).
- 4.1.0 is unused on npm; trusted publishing already worked for v4.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)